### PR TITLE
Add optional return data for traces

### DIFF
--- a/src/schemas/ots-types.yaml
+++ b/src/schemas/ots-types.yaml
@@ -431,4 +431,5 @@ TraceEntry:
       $ref: '#/components/schemas/bytes'
     output:
       title: return data of the operation
+      description: this value is optional for backward compatibility with old implementations that don't support it
       $ref: '#/components/schemas/bytes'

--- a/src/schemas/ots-types.yaml
+++ b/src/schemas/ots-types.yaml
@@ -429,3 +429,6 @@ TraceEntry:
     input:
       title: calldata of the operation
       $ref: '#/components/schemas/bytes'
+    output:
+      title: return data of the operation
+      $ref: '#/components/schemas/bytes'


### PR DESCRIPTION
This PR adds an optional field to the traces specs.

That'll allow the trace view to display return values per call. It is optional in order to not break implementations based on old specs, i.e. old Otterscan versions will ignore the extra field from newer Erigon versions, and new Otterscan versions will not break when running against newer Erigon versions tha don't return this field (it'll not render the return value)